### PR TITLE
Support new mongodb driver

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,19 @@ var TestConnection = function (db) {
 };
 
 TestConnection.prototype._connect = function (cb) {
-  if (this._db.serverConfig.connected) return cb();
+  try {
+    var version = this._db.serverConfig.clientInfo.driver.version;
+    var versionNumber = Number(version.split('.').slice(0, 2).join().replace(/\D/g, ''));
+  } catch (err) {
+    throw new Error('Cannot read mongodb driver version');
+  }
+
+  if (versionNumber >= 22) {
+    if (this._db.serverConfig.isConnected()) return cb();
+  } else {
+    if (this._db.serverConfig.connected) return cb();
+  }
+
   this._db.open(cb);
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb-fixture",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "MongoDB fixture utility for testing",
   "keywords": [
     "mongodb",


### PR DESCRIPTION
New mongodb drivers does not support serverConfig.connected notation.

Added a small piece of code to test the driver version.
It's to avoid having this error: "server instance in invalid state undefined".